### PR TITLE
FIX : Clonage OR 

### DIFF
--- a/class/actions_dolifleet.class.php
+++ b/class/actions_dolifleet.class.php
@@ -73,22 +73,6 @@ class ActionsdoliFleet
 		if (in_array('operationordercard', $contextArray) && $action == 'clone') {
 			$action = 'cloneOR';
 		}
-	}
-
-	public function addMoreActionsButtons($parameters, &$object, &$action, $hookmanager){
-
-		global $conf, $langs, $user, $db;
-		$contextArray = explode(':', $parameters['context']);
-
-		if (in_array('operationordercard', $contextArray) && $action == 'cloneOR') {
-			$form = new Form($db);
-			$fk_status = GETPOST('fk_status' , 'int');
-			$formquestion = array ( 'text' => $langs->trans("ConfirmClone"),
-				array('type' => 'other', 'name' => 'select_fk_vehicule', 'label' => $langs->trans("SelectVehicule"), 'value' => $form->selectForForms('doliFleetVehicule:dolifleet/class/vehicule.class.php', "select_fk_vehicule", $object->array_options['options_fk_dolifleet_vehicule'])));
-			$body = $langs->trans('ConfirmCloneOperationOrderBody', $object->ref);
-			$formconfirm = $form->formconfirm($_SERVER['PHP_SELF'] . '?id=' . $object->id.'&fk_status='.$fk_status, $langs->trans('ConfirmCloneOperationOrderTitle'), $body, 'confirm_cloneOR', $formquestion, 0, 1);
-			print $formconfirm;
-		}
 
 		if (in_array('operationordercard', $contextArray) && $action == 'confirm_cloneOR' && !empty($user->rights->operationorder->write)) {
 			$newid = $object->cloneObject($user);
@@ -112,6 +96,24 @@ class ActionsdoliFleet
 				dol_print_error($db);
 			}
 		}
+	}
+
+	public function addMoreActionsButtons($parameters, &$object, &$action, $hookmanager){
+
+		global $conf, $langs, $user, $db;
+		$contextArray = explode(':', $parameters['context']);
+
+		if (in_array('operationordercard', $contextArray) && $action == 'cloneOR') {
+			$form = new Form($db);
+			$fk_status = GETPOST('fk_status' , 'int');
+			$formquestion = array ( 'text' => $langs->trans("ConfirmClone"),
+				array('type' => 'other', 'name' => 'select_fk_vehicule', 'label' => $langs->trans("SelectVehicule"), 'value' => $form->selectForForms('doliFleetVehicule:dolifleet/class/vehicule.class.php', "select_fk_vehicule", $object->array_options['options_fk_dolifleet_vehicule'])));
+			$body = $langs->trans('ConfirmCloneOperationOrderBody', $object->ref);
+			$formconfirm = $form->formconfirm($_SERVER['PHP_SELF'] . '?id=' . $object->id.'&fk_status='.$fk_status, $langs->trans('ConfirmCloneOperationOrderTitle'), $body, 'confirm_cloneOR', $formquestion, 0, 1);
+			print $formconfirm;
+		}
+
+
 		/*$error = 0; // Error counter
 		$myvalue = 'test'; // A result value
 

--- a/langs/fr_FR/dolifleet.lang
+++ b/langs/fr_FR/dolifleet.lang
@@ -186,3 +186,5 @@ ErrDuplicateMatrix=Il existe déjà une ligne de matrice pour ce type, cette mar
 ErrVehiculeThirPartiesAreDifferent=Les tiers des véhicules à lier sont différents
 ErrEmptyVehiculeImmatDate=Date de mise en circulation invalide
 ErrInvalidSocid=Tiers invalide
+
+SelectVehicule=Selection de vehicule :


### PR DESCRIPTION
### FIX : Clonage OR 

**Ajout de la possibilité, au clonage d'un OR, de sélectionner un autre véhicule pour l'OR cloné** : 
- Ajout d'un select (liste déroulante) des véhicules dans la pop-up de confirmation lors du clonage d'un OR 
- Possibilité de changer de véhicule lors du clonage, le clone est crée en conséquence 
- Présélection du select par le véhicule associé à l'OR depuis lequel on clone
- Mise à jour du kilométrage et du tiers du clone selon le véhicule sélectionné 